### PR TITLE
Verify that the native handle was created

### DIFF
--- a/libs/binder/Parcel.cpp
+++ b/libs/binder/Parcel.cpp
@@ -1224,6 +1224,10 @@ native_handle* Parcel::readNativeHandle() const
     if (err != NO_ERROR) return 0;
 
     native_handle* h = native_handle_create(numFds, numInts);
+    if (!h) {
+        return 0;
+    }
+
     for (int i=0 ; err==NO_ERROR && i<numFds ; i++) {
         h->data[i] = dup(readFileDescriptor());
         if (h->data[i] < 0) err = BAD_VALUE;


### PR DESCRIPTION
The inputs to native_handle_create can cause an overflowed allocation,
so check the return value of native_handle_create before accessing
the memory it returns.

Bug:19334482
Change-Id: I1f489382776c2a1390793a79dc27ea17baa9b2a2
(cherry picked from commit eaac99a7172da52a76ba48c26413778a74951b1a)